### PR TITLE
Upgrade build tools for Android

### DIFF
--- a/cocos2dx/platform/android/java/build.gradle
+++ b/cocos2dx/platform/android/java/build.gradle
@@ -5,8 +5,8 @@ android {
     buildToolsVersion "22.0.1"
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 21
+        minSdkVersion 14
+        targetSdkVersion 22
     }
 
     buildTypes {

--- a/cocos2dx/platform/android/java/build.gradle
+++ b/cocos2dx/platform/android/java/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         minSdkVersion 10


### PR DESCRIPTION
Version 21.1.1 has become obsolete. Upgrade to the version that Lumosity is currently using.

@lumoslabs/android 